### PR TITLE
Typos in RDF/Turtle of Core Ontology, extensions, and examples

### DIFF
--- a/rdf/ontology/abstract.ttl
+++ b/rdf/ontology/abstract.ttl
@@ -46,7 +46,7 @@
     rdfs:range :Reference ;
     rdfs:subPropertyOf oa:hasTarget ;
     rdfs:label "there"@en ;
-    rfdf:Comment "The resource (text) to which a more or less manifest intertextual relation is observed. As a rule of thumb, the resource referenced with this property is chronologically older than the one referenced with the property 'here'."@en .
+    rfds:comment "The resource (text) to which a more or less manifest intertextual relation is observed. As a rule of thumb, the resource referenced with this property is chronologically older than the one referenced with the property 'here'."@en .
     # TODO: left-totality
 
 :specifiedBy

--- a/rdf/ontology/abstract.ttl
+++ b/rdf/ontology/abstract.ttl
@@ -46,7 +46,7 @@
     rdfs:range :Reference ;
     rdfs:subPropertyOf oa:hasTarget ;
     rdfs:label "there"@en ;
-    rfds:comment "The resource (text) to which a more or less manifest intertextual relation is observed. As a rule of thumb, the resource referenced with this property is chronologically older than the one referenced with the property 'here'."@en .
+    rdfs:comment "The resource (text) to which a more or less manifest intertextual relation is observed. As a rule of thumb, the resource referenced with this property is chronologically older than the one referenced with the property 'here'."@en .
     # TODO: left-totality
 
 :specifiedBy

--- a/rdf/ontology/abstract.ttl
+++ b/rdf/ontology/abstract.ttl
@@ -5,28 +5,28 @@
 
 <https://intertextuality.org/abstract>
     a owl:Ontology ;
-    rdfs:Label "Core Ontology for Intertextual Relations"@en .
+    rdfs:label "Core Ontology for Intertextual Relations"@en .
 
 # 1. Classes
 
 :IntertextualRelation
     a owl:Class ;
-    rdfs:Label "Intertextual Relation"@en .
+    rdfs:label "Intertextual Relation"@en .
 
 :Reference
     a owl:Class ;
-    rdfs:Label "Resource"@en ;
-    rdfs:Comment "The resources between which an intertextual relation is recorded have to be instances of this class."@en .
+    rdfs:label "Resource"@en ;
+    rdfs:comment "The resources between which an intertextual relation is recorded have to be instances of this class."@en .
 
 :IntertextualSpecification
     a owl:Class ;
-    rdfs:Label "Specification of intertextual relations"@en ;
+    rdfs:label "Specification of intertextual relations"@en ;
     rdfs:comment "Specifications for intertextual relations have to be a instances this class and should be bundled in subclasses following some domain- or theory-specific system."@en .
 
 :Mediator
     a owl:Class ;
-    rdfs:Label "Mediator"@en ;
-    rdfs:Comment "Mediators for intertextual relations must be a instances of this class and should be bundled in subclasses following some system."@en .
+    rdfs:label "Mediator"@en ;
+    rdfs:comment "Mediators for intertextual relations must be a instances of this class and should be bundled in subclasses following some system."@en .
 
 
 # 2. Predicates
@@ -36,8 +36,8 @@
     rdfs:domain :IntertextualRelation ;
     rdfs:range :Reference ;
     rdfs:subPropertyOf oa:hasTarget ;
-    rdfs:Label "here"@en ;
-    rdfs:Comment "The (textual) resource that has a more or less manifest intertextual relation to another text. As a rule of thumb, the resource referenced with this property is chronologically younger than the one referenced with the property 'there'."@en .
+    rdfs:label "here"@en ;
+    rdfs:comment "The (textual) resource that has a more or less manifest intertextual relation to another text. As a rule of thumb, the resource referenced with this property is chronologically younger than the one referenced with the property 'there'."@en .
     # TODO: left-totality
 
 :there
@@ -45,7 +45,7 @@
     rdfs:domain :IntertextualRelation ;
     rdfs:range :Reference ;
     rdfs:subPropertyOf oa:hasTarget ;
-    rdfs:Label "there"@en ;
+    rdfs:label "there"@en ;
     rfdf:Comment "The resource (text) to which a more or less manifest intertextual relation is observed. As a rule of thumb, the resource referenced with this property is chronologically older than the one referenced with the property 'here'."@en .
     # TODO: left-totality
 
@@ -54,8 +54,8 @@
     rdfs:domain :IntertextualRelation ;
     rdfs:range :IntertextualSpecification ;
     rdfs:subPropertyOf oa:hasBody ;
-    rdfs:Label "specified by"@en ;
-    rdfs:Comment "Each intertextual relation has to be specified by a category following a more or less common theoretical notion."@en .
+    rdfs:label "specified by"@en ;
+    rdfs:comment "Each intertextual relation has to be specified by a category following a more or less common theoretical notion."@en .
     # TODO: left-totality
 
 :mediatedBy
@@ -63,8 +63,8 @@
     rdfs:domain :IntertextualRelation ;
     rdfs:range :Mediator ;
     rdfs:subPropertyOf oa:hasBody ;
-    rdfs:Label "mediated by"@en ;
-    rdfs:Comment "Intertextual relations may be established by a mediator, e.g. a motive."@en .
+    rdfs:label "mediated by"@en ;
+    rdfs:comment "Intertextual relations may be established by a mediator, e.g. a motive."@en .
 
 
 # 3. Enable recursive/transitive intertextual relation via instances of :Mediator.

--- a/rdf/ontology/abstract.ttl
+++ b/rdf/ontology/abstract.ttl
@@ -21,7 +21,7 @@
 :IntertextualSpecification
     a owl:Class ;
     rdfs:Label "Specification of intertextual relations"@en ;
-    rdfs:Comemnt "Specifications for intertextual relations have to be a instances this class and should be bundled in subclasses following some domain- or theory-specific system."@en .
+    rdfs:comment "Specifications for intertextual relations have to be a instances this class and should be bundled in subclasses following some domain- or theory-specific system."@en .
 
 :Mediator
     a owl:Class ;

--- a/rdf/ontology/extensions/artifacts.ttl
+++ b/rdf/ontology/extensions/artifacts.ttl
@@ -1,26 +1,27 @@
 @prefix a: <https://intertextuality.org/extensions/artifacts#> .
 @prefix : <https://intertextuality.org/abstract#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 
 <https://intertextuality.org/extensions/artifacts>
     a owl:Ontology ;
-    rdfs:Label "Analytic Levels Ontology"@en ;
-    rdfs:Comment "This ontology defines categories for analytic access (to artifacts) on different levels: works, segments, and systems."@en .
+    rdfs:label "Analytic Levels Ontology"@en ;
+    rdfs:comment "This ontology defines categories for analytic access (to artifacts) on different levels: works, segments, and systems."@en .
 
 a:Work
     a owl:Class ;
-    rdfs:Label "Work"@en ;
-    rdfs:Comment "An artifact as a somehow delimited entity, that is a whole in some respect: an aesthetic or functional whole, an entire communicative act etc."@en .
+    rdfs:label "Work"@en ;
+    rdfs:comment "An artifact as a somehow delimited entity, that is a whole in some respect: an aesthetic or functional whole, an entire communicative act etc."@en .
 
 a:Segment
     a owl:Class ;
-    rdfs:Label "Segment"@en ;
-    rdfs:Comment "A part of a work."@en .
+    rdfs:label "Segment"@en ;
+    rdfs:comment "A part of a work."@en .
 
 a:System
     a owl:Class ;
-    rdfs:Label "System"@en ;
-    rdfs:Comment "A set of structures significant for a set of works."@en .
+    rdfs:label "System"@en ;
+    rdfs:comment "A set of structures significant for a set of works."@en .
 
 a:Artifact
     owl:disjointUnionOf (a:Segment a:Work a:System) .

--- a/rdf/ontology/extensions/genette/hypertextuality.ttl
+++ b/rdf/ontology/extensions/genette/hypertextuality.ttl
@@ -6,8 +6,8 @@
 <https://intertextuality.org/extensions/genette/hypertextuality>
     a owl:Ontology ;
     owl:imports <https://intertextuality.org/abstract> ;
-    rdfs:Label "Genette's Hypertextual Relations"@en ;
-    rdfs:Comment "Ontology formalizing Gérard Genettes system of hypertextual relations as developed in his 1982 book 'Palimpsests'."@en .
+    rdfs:label "Genette's Hypertextual Relations"@en ;
+    rdfs:comment "Ontology formalizing Gérard Genettes system of hypertextual relations as developed in his 1982 book 'Palimpsests'."@en .
 
 g:HypertextualRelation
     rdfs:subClassOf :IntertextualSpecification ;
@@ -30,29 +30,29 @@ g:hasModalType
 g:parody
     g:hasRelationalType g:transformation ;
     g:hasModelType g:playfully ;
-    rdfs:Label "Parody, i.e. a playful transformation"@en .
+    rdfs:label "Parody, i.e. a playful transformation"@en .
 
 g:pastiche
     g:hasRelationalType g:imitation ;
     g:hasModalType g:playfully ;
-    rdfs:Label "Pastiche, i.e. a playful imitation"@en .
+    rdfs:label "Pastiche, i.e. a playful imitation"@en .
 
 g:travesty
     g:hasRelationalType g:transformation ;
     g:hasModalType g:satirically ;
-    rdfs:Label "Travesty, i.e. a satirical transformation"@en .
+    rdfs:label "Travesty, i.e. a satirical transformation"@en .
 
 g:persiflage
     g:hasRelationalType g:imitation ;
     g:hasModalType g:satirically ;
-    rdfs:Label "Persiflage, i.e. a satirical imitation"@en .
+    rdfs:label "Persiflage, i.e. a satirical imitation"@en .
 
 g:transposition
     g:hasRelationalType g:transformation ;
     g:hasModalType g:seriously ;
-    rdfs:Label "Transposition, i.e. a serious transformation"@en .
+    rdfs:label "Transposition, i.e. a serious transformation"@en .
 
 g:replication
     g:hasRelationalType g:imitation ;
     g:hasModalType g:seriously ;
-    rdfs:Label "Replication, i.e. a serious imitation"@en .
+    rdfs:label "Replication, i.e. a serious imitation"@en .

--- a/rdf/ontology/extensions/genette/paratext.ttl
+++ b/rdf/ontology/extensions/genette/paratext.ttl
@@ -5,12 +5,12 @@
 
 <https://intertextuality.org/extensions/genette/paratext>
     a owl:Ontology ;
-    rdfs:Label "Paratextual Signals Ontology"@en ;
-    rdfs:Comment "An ontology for paratextual signals that inaugurate intertextual relations according to Gérard Genette."@en .
+    rdfs:label "Paratextual Signals Ontology"@en ;
+    rdfs:comment "An ontology for paratextual signals that inaugurate intertextual relations according to Gérard Genette."@en .
 
 pt:ParatextualSignal
     rdfs:subClassOf :Mediator ;
-    rdfs:Label "Paratextual Signal"@en .
+    rdfs:label "Paratextual Signal"@en .
 
 # an open list of paratextual signals:
 

--- a/rdf/ontology/extensions/motives.ttl
+++ b/rdf/ontology/extensions/motives.ttl
@@ -5,15 +5,15 @@
 
 <https://intertextuality.org/extensions/motives>
     a owl:Ontology ;
-    rdfs:Label "Motives"@en .
+    rdfs:label "Motives"@en .
 
 m:Motive
     rdfs:subClassOf :Mediator ;
-    rdfs:Label "Motive"@en ;
-    rdfs:Comment "A motive can function as a intertextual mediator."@en .
+    rdfs:label "Motive"@en ;
+    rdfs:comment "A motive can function as a intertextual mediator."@en .
 
 # Potentially endless list of motives:
 
 m:HorsesInAPigsty
     a m:Motive ;
-    rdfs:Label "Motive \"Horses in a pigsty\""@en .
+    rdfs:label "Motive \"Horses in a pigsty\""@en .

--- a/rdf/ontology/extensions/text.ttl
+++ b/rdf/ontology/extensions/text.ttl
@@ -7,28 +7,28 @@
 <https://intertextuality.org/extensions/text>
     a owl:Ontology ;
     owl:imports <https://intertextuality.org/extensions/artifacts> ;
-    rdfs:Label "Text Ontology"@en ;
-    rdfs:Comment "This ontology defines categories for analytic access to text on different levels: works, segments, and genres."@en .
+    rdfs:label "Text Ontology"@en ;
+    rdfs:comment "This ontology defines categories for analytic access to text on different levels: works, segments, and genres."@en .
 
 t:Text
     a owl:Class ;
     # rdfs:subClassOf a:Artifact ;
-    rdfs:Label "Text"@en ;
-    rdfs:Comment "The class of artifacts denominated as text."@en .
+    rdfs:label "Text"@en ;
+    rdfs:comment "The class of artifacts denominated as text."@en .
 
 t:TextSegment
     owl:intersectionOf (t:Text a:Segment) ;
-    rdfs:Label "Text Segment"@en ;
-    rdfs:Comment "A segment of a text, i.e. a passage of a single text or work."@en .
+    rdfs:label "Text Segment"@en ;
+    rdfs:comment "A segment of a text, i.e. a passage of a single text or work."@en .
 
 t:SingleText
     owl:intersectionOf (t:Text  a:Work) ;
-    rdfs:Label "Single text"@en ;
-    rdfs:Comment "A single text is a somehow delimited text as a whole, the kind of thing denominated with terms like book, document, work, even if it's handed down only as a fragment."@en .
+    rdfs:label "Single text"@en ;
+    rdfs:comment "A single text is a somehow delimited text as a whole, the kind of thing denominated with terms like book, document, work, even if it's handed down only as a fragment."@en .
 
 t:TextGenre
     owl:intersectionOf (t:Text a:System) ;
-    rdfs:Label "Textual Genre"@en .
+    rdfs:label "Textual Genre"@en .
 
 t:here
     rdfs:subPropertyOf :here ;

--- a/rdf/samples/kafka-kleist-homer.ttl
+++ b/rdf/samples/kafka-kleist-homer.ttl
@@ -24,7 +24,7 @@ ex:itr3
     a :IntertextualRelation ;
     :here ex:landarztPigsty ;
     :there ex:iliadAutomedonsPlummet ;
-    :specifiedBy _undefSepc ;
+    :specifiedBy _undefSpec ;
     :mediatedBy ex:itr2 ;
     rdfs:comment "a transitive intertextual relation mediated by ex:itr1 and ex:itr2."@en .
 

--- a/rdf/samples/kafka-kleist-homer.ttl
+++ b/rdf/samples/kafka-kleist-homer.ttl
@@ -10,7 +10,7 @@ ex:itr1
     :there ex:kohlhaasPigsty ;
     :specifiedBy _undefSpec ;
     :mediatedBy m:HorsesInAPigsty ;
-    rdfs:Comment "intertextual relation between segments of Kafka's \"Ein Landarzt\" and Kleist's \"Michael Kohlhaas\"."@en .
+    rdfs:comment "intertextual relation between segments of Kafka's \"Ein Landarzt\" and Kleist's \"Michael Kohlhaas\"."@en .
 
 ex:itr2
     a :IntertextualRelation ;
@@ -18,7 +18,7 @@ ex:itr2
     :there ex:iliadAutomedonsPlummet ;
     :specifiedBy _undefSpec ;
     :mediatedBy m:HorsesAndGeese ;
-    rdfs:Comment "intertextual relation between segments of Kleist's \"Michael Kohlhaas\" and Homer's \"Iliad\"."@en .
+    rdfs:comment "intertextual relation between segments of Kleist's \"Michael Kohlhaas\" and Homer's \"Iliad\"."@en .
 
 ex:itr3
     a :IntertextualRelation ;
@@ -26,16 +26,16 @@ ex:itr3
     :there ex:iliadAutomedonsPlummet ;
     :specifiedBy _undefSepc ;
     :mediatedBy ex:itr2 ;
-    rdfs:Comment "a transitive intertextual relation mediated by ex:itr1 and ex:itr2."@en .
+    rdfs:comment "a transitive intertextual relation mediated by ex:itr1 and ex:itr2."@en .
 
 _undefSpec
     a :IntertextualSpecification
-    rdfs:Comment "The intertextual relation is not further specified by Borgstedt"@en .
+    rdfs:comment "The intertextual relation is not further specified by Borgstedt"@en .
 
 m:HorsesAndGeese
     a m:Motive
-    rdfs:Label "Horses and Geese"@en ;
-    rdfs:Comment "A Horse and a goose, or several of them in some association, like substitution, simile, juxtaposition etc."@en .
+    rdfs:label "Horses and Geese"@en ;
+    rdfs:comment "A Horse and a goose, or several of them in some association, like substitution, simile, juxtaposition etc."@en .
 
 ex:landarztPigsty
     oa:hasSource <https://textgridlab.org/1.0/tgcrud-public/rest/textgrid:qn00.0/data>;

--- a/rdf/samples/kafka-kleist-homer.ttl
+++ b/rdf/samples/kafka-kleist-homer.ttl
@@ -8,7 +8,7 @@ ex:itr1
     a :IntertextualRelation ;
     :here ex:landarztPigsty ;
     :there ex:kohlhaasPigsty ;
-    :specifiedBy _undefSpec ;
+    :specifiedBy _:undefSpec ;
     :mediatedBy m:HorsesInAPigsty ;
     rdfs:comment "intertextual relation between segments of Kafka's \"Ein Landarzt\" and Kleist's \"Michael Kohlhaas\"."@en .
 
@@ -16,7 +16,7 @@ ex:itr2
     a :IntertextualRelation ;
     :here ex:kohlhaasPigsty ;
     :there ex:iliadAutomedonsPlummet ;
-    :specifiedBy _undefSpec ;
+    :specifiedBy _:undefSpec ;
     :mediatedBy m:HorsesAndGeese ;
     rdfs:comment "intertextual relation between segments of Kleist's \"Michael Kohlhaas\" and Homer's \"Iliad\"."@en .
 
@@ -24,16 +24,16 @@ ex:itr3
     a :IntertextualRelation ;
     :here ex:landarztPigsty ;
     :there ex:iliadAutomedonsPlummet ;
-    :specifiedBy _undefSpec ;
+    :specifiedBy _:undefSpec ;
     :mediatedBy ex:itr2 ;
     rdfs:comment "a transitive intertextual relation mediated by ex:itr1 and ex:itr2."@en .
 
-_undefSpec
-    a :IntertextualSpecification
+_:undefSpec
+    a :IntertextualSpecification ;
     rdfs:comment "The intertextual relation is not further specified by Borgstedt"@en .
 
 m:HorsesAndGeese
-    a m:Motive
+    a m:Motive ;
     rdfs:label "Horses and Geese"@en ;
     rdfs:comment "A Horse and a goose, or several of them in some association, like substitution, simile, juxtaposition etc."@en .
 


### PR DESCRIPTION
There are some errors/typos in the RDF/Turtle files (e.g. rdfs:Comment instead of rdfs:comment).

- [x] One typo found in a comment
- [x] Fix upper/lower case
- [x] Fix prefix error and uppercase typo (rfdf:Comment) in abstract.ttl  
- [x] Add missing prefix rdfs: in artifacts.ttl
- [x] Fix uppercase typos in extentions
- [x] Fix uppercase typos in kafka-kleist-homer.ttl example
- [x] Fix typo (_undefSepc) in kafka-kleist-homer.ttl example
- [x] Fix _undefSpec missing prefix token ':' in kafka-kleist-homer.ttl example -- should be `_:undefSpec` ?!